### PR TITLE
removed html-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "webpack": "*",
     "webpack-cli": "*",
     "webpack-dev-server": "*",
-    "html-loader": "*",
     "html-webpack-plugin": "*"
   },
   "bin": {},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,10 +31,6 @@ module.exports = {
         }
       },
       {
-        test: /\.html$/,
-        use: [{ loader: 'html-loader' }]
-      },
-      {
         test: /\.css$/,
         loader: 'style-loader!css-loader'
       },


### PR DESCRIPTION
Denna PR löser ett problem med webpackkonfigurationen som jag stötte på. 
Den här kursen kommer visserligen att avslutas men jag antar att ni kommer att ha samma problem i andra projekt så det kanske kan vara till nytta ändå :)

### Så här kan problemet reproduceras:
1. Klona repot
2. Kör `npm install`
2. Ladda app.js via en script-tagg i index.html
3. Lägg till en rad i app.js som refererar window eller document-objekten. Tex: `window.alert('test')`. Avsluta med radbrytning.
4. Kör `npm start`.

### Förväntat utfall: 
koden kompilerar, och javascriptet fungerar när du surfar till localhost med en webbläsare.

### Faktiskt utfall: 
Koden kompilerar inte. Webpack klagar på att window (eller document om du använde det i ditt javascript) inte är definierat.

Det verkar som att felet har med Webpack 4 eller html-loader 2.* att göra. Så jag antar att det fungerade när repot skapades, men eftersom inga exakta versioner av Webpack eller html-loader specificeras i package.json fungerar det inte längre nu när man installerar och får de senaste versionerna.

Denna PR tar bort html-loader och då fungerar allt. Nackdelen är att html-filen inte blir minifierad i produktionsläge, men det lär väl inte ha så stor betydelse.